### PR TITLE
Fix Dockerfile and tests

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,18 @@
 # 基于官方 FastAPI 镜像
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
 
-# 把代码复制进 /app（镜像默认工作目录）
-COPY . /app
+# 设置工作目录
+WORKDIR /app
+
+# 复制 API 代码
+COPY ./api /app
+
+# 复制数据库文件
+COPY ./data /app/data
 
 # 安装依赖
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-# 确保 data 目录可访问（如果你的 DB 在 ../data）
-RUN mkdir -p /app/data
 # （如果要把宿主机 data 挂载进来可在运行时指定 -v）
 
 # 默认启动命令无需改，镜像会自动跑:

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -9,7 +9,10 @@ def test_health():
     assert r.json() == {"status":"ok"}
 
 def test_data_endpoint():
-    r = client.get("/data?startdate=2025-01-01&enddate=2025-07-25&limit=1")
+    r = client.get(
+        "/szse_etf_shares/data?startdate=2025-01-01&enddate=2025-07-25&limit=1"
+    )
     assert r.status_code == 200
-    data = r.json()
-    assert isinstance(data, list)
+    payload = r.json()
+    assert "data" in payload
+    assert isinstance(payload["data"], list)


### PR DESCRIPTION
## Summary
- ship DB files inside API Docker image
- correct data endpoint test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68839fffb924832ab2a66dc0ee408936